### PR TITLE
HatterTheMadd-dev-manifest-v3-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ The original author decided to be a bitch by adding his amazon ref-link to his c
 
 # Credits
 - [@saucettv](https://github.com/saucettv) (original Author)
-- [@mikirobles](https://github.com/cleanlock)
+- [@mikirobles](https://github.com/cleanlock) (thanks for removing the Donation-Stuff etc.)

--- a/content.js
+++ b/content.js
@@ -1,29 +1,15 @@
 //Get extension settings.
-//Check if Firefox or not.
-const isFirefox = !chrome.app;
 
 function updateSettings() {
-    if (isFirefox) {
-        var hideBlockingMessage = browser.storage.sync.get('blockingMessageTTV');
-        hideBlockingMessage.then((res) => {
-            if (res.blockingMessageTTV == "true" || res.blockingMessageTTV == "false") {
-                window.postMessage({
-                    type: "SetHideBlockingMessage",
-                    value: res.blockingMessageTTV
-                }, "*");
-            }
-        });
-    } else {
-        chrome.storage.local.get(['blockingMessageTTV'], function(result) {
-            if (result.blockingMessageTTV == "true" || result.blockingMessageTTV == "false") {
-                window.postMessage({
-                    type: "SetHideBlockingMessage",
-                    value: result.blockingMessageTTV
-                }, "*");
-            }
-        });
-    }
-}
+	try {
+		 chrome.storage.local.get(['blockingMessageTTV'], function(result) {
+		 if (result.blockingMessageTTV == "true" || result.blockingMessageTTV == "false") {
+			window.postMessage({
+				type: "SetHideBlockingMessage",
+				value: result.blockingMessageTTV
+			}, "*");
+		}
+	});
 
 function removeVideoAds() {
     //This stops Twitch from pausing the player when in another tab and an ad shows.
@@ -807,20 +793,8 @@ function appendBlockingScript() {
     }, 4000);
 }
 
-if (isFirefox) {
-    var onOff = browser.storage.sync.get('onOffTTV');
-    onOff.then((res) => {
-        if (res && res.onOffTTV) {
-            if (res.onOffTTV == "true") {
-                appendBlockingScript();
-            }
-        } else {
-            appendBlockingScript();
-        }
-    }, err => {
-        appendBlockingScript();
-    });
-} else {
+function chromeStorage() {
+    try {
     chrome.storage.local.get(['onOffTTV'], function(result) {
         if (chrome.runtime.lastError) {
             appendBlockingScript();


### PR DESCRIPTION
### content.js
+ removed references to firefox that were causing issues in Manifest v3.

### manifest.js
+ removed depreciated call 'webRequestBlocking' this was replaced with 'declarativeNetRequest' which is already included.

### Notes
+ I tested this with several twitch channels. It seems some ads are not being blocked. This might be due to the depreciation of webRequestBlock. Which some stack exchange and forums list googles response to this as "for privacy" but in reality it looks like they are trying to completely reomve all ad-blocking technology from plugins and their browser.
+ Unless someone comes up with something by the time it gets removed I don't think this is going to work anymore. At least not 100% of the time.