### PR TITLE
Fix importScripts errors

### DIFF
--- a/chrome/remove_video_ads.js
+++ b/chrome/remove_video_ads.js
@@ -90,7 +90,7 @@ window.Worker = class Worker extends oldWorker {
             super(twitchBlobUrl);
             return;
         }
-        var jsURL = getWasmWorkerUrl(twitchBlobUrl);
+        var jsURL = twitchBlobUrl;
         if (typeof jsURL !== 'string') {
             super(twitchBlobUrl);
             return;
@@ -215,7 +215,7 @@ window.Worker = class Worker extends oldWorker {
                                             }
                                         }
                                         var currentQualityLS = window.localStorage.getItem('video-quality');
-                                        
+
                                         lowQuality[qualityToSelect].click();
                                         window.localStorage.setItem('video-quality', currentQualityLS);
 
@@ -256,13 +256,6 @@ window.Worker = class Worker extends oldWorker {
         }
     }
 };
-
-function getWasmWorkerUrl(twitchBlobUrl) {
-    var req = new XMLHttpRequest();
-    req.open('GET', twitchBlobUrl, false);
-    req.send();
-    return req.responseText.split("'")[1];
-}
 
 function hookWorkerFetch() {
     var realFetch = fetch;

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -118,7 +118,7 @@ function removeVideoAds() {
                 super(twitchBlobUrl);
                 return;
             }
-            var jsURL = getWasmWorkerUrl(twitchBlobUrl);
+            var jsURL = twitchBlobUrl;
             if (typeof jsURL !== 'string') {
                 super(twitchBlobUrl);
                 return;
@@ -243,7 +243,7 @@ function removeVideoAds() {
                                                 }
                                             }
                                             var currentQualityLS = window.localStorage.getItem('video-quality');
-                                            
+
                                             lowQuality[qualityToSelect].click();
                                             window.localStorage.setItem('video-quality', currentQualityLS);
 
@@ -284,13 +284,6 @@ function removeVideoAds() {
             }
         }
     };
-
-    function getWasmWorkerUrl(twitchBlobUrl) {
-        var req = new XMLHttpRequest();
-        req.open('GET', twitchBlobUrl, false);
-        req.send();
-        return req.responseText.split("'")[1];
-    }
 
     function hookWorkerFetch() {
         var realFetch = fetch;


### PR DESCRIPTION
Running into a `SyntaxError: WorkerGlobalScope.importScripts: Failed to load worker script at "type ""` where the `getWasmWorkerUrl` method is returning `type "`, an invalid url.

It seems like `twitchBlobUrl` itself is returning the correct url for the wasmworker script anyway, i.e. `https://www.twitch.tv/assets/amazon-ivs-wasmworker.min-5526a9c4389a99792948.js`, so it seems as though the method `getWasmWorkerUrl` isn't needed anymore?

Simply returning the `twitchBlobUrl` resolves the issues for firefox/chrome.

Feel free to close if this change is inappropriate. 

Cheers for extension! 🍻 