### PR TITLE
Hybrid embed, proxy, fallback implementation

### DIFF
--- a/chrome/remove_video_ads.js
+++ b/chrome/remove_video_ads.js
@@ -60,16 +60,19 @@ function declareOptions(scope) {
     scope.ClientID = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
     scope.ClientVersion = 'null';
     scope.ClientSession = 'null';
-    scope.PlayerType1 = 'site'; //Source
-    scope.PlayerType2 = 'thunderdome'; //480p
-    scope.PlayerType3 = 'pop_tart'; //480p
-    scope.PlayerType4 = 'picture-by-picture'; //360p
+    //scope.PlayerType1 = 'site'; //Source - NOTE: This is unused as it's implicitly used by the website iself
+    scope.PlayerType2 = 'embed'; //Source
+    scope.PlayerType3 = 'proxy'; //Source
+    scope.PlayerType4 = 'thunderdome'; //480p
     scope.CurrentChannelName = null;
     scope.UsherParams = null;
     scope.WasShowingAd = false;
     scope.GQLDeviceID = null;
     scope.HideBlockingMessage = false;
     scope.IsSquadStream = false;
+    scope.StreamInfos = [];
+    scope.StreamInfosByUrl = [];
+    scope.MainUrlByUrl = [];
 }
 
 declareOptions(window);
@@ -96,7 +99,10 @@ window.Worker = class Worker extends oldWorker {
             return;
         }
         var newBlobStr = `
-            ${getNewUsher.toString()}
+            ${shouldForceChangeQuality.toString()}
+            ${getStreamUrlForResolution.toString()}
+            ${getStreamForResolution.toString()}
+            ${stripUnusedParams.toString()}
             ${processM3U8.toString()}
             ${hookWorkerFetch.toString()}
             ${declareOptions.toString()}
@@ -265,6 +271,7 @@ function getWasmWorkerUrl(twitchBlobUrl) {
 }
 
 function hookWorkerFetch() {
+    console.log('Twitch adblocker is enabled');
     var realFetch = fetch;
     fetch = async function(url, options) {
         if (typeof url === 'string') {
@@ -304,73 +311,119 @@ function hookWorkerFetch() {
                 if (isPBYPRequest) {
                     url = '';
                 }
-                //Make new Usher request if needed to create fallback if UBlock bypass method fails.
-                var useNewUsher = false;
-                if (url.includes('subscriber%22%3Afalse') && url.includes('hide_ads%22%3Afalse') && url.includes('show_ads%22%3Atrue')) {
-                    useNewUsher = true;
-                }
-                if (url.includes('subscriber%22%3Atrue') && url.includes('hide_ads%22%3Afalse') && url.includes('show_ads%22%3Atrue')) {
-                    useNewUsher = true;
-                }
-                if (useNewUsher == true) {
-                    return new Promise(function(resolve, reject) {
-                        var processAfter = async function(response) {
-                            encodingsM3u8 = await getNewUsher(realFetch, response, channelName);
-                            if (encodingsM3u8.length > 1) {
-                                resolve(new Response(encodingsM3u8));
-                            } else {
-                                postMessage({
-                                    key: 'HideAdBlockBanner'
-                                });
-                                resolve(encodingsM3u8);
+                return new Promise(function(resolve, reject) {
+                    var processAfter = async function(response) {
+                        encodingsM3u8 = await response.text();
+                        var streamInfo = StreamInfos[channelName];
+                        if (streamInfo == null) {
+                            StreamInfos[channelName] = streamInfo = {};
+                        }
+                        streamInfo.ChannelName = channelName;
+                        streamInfo.Urls = [];// xxx.m3u8 -> "284x160" (resolution)
+                        streamInfo.EncodingsM3U8Cache = [];
+                        var lines = encodingsM3u8.replace('\r', '').split('\n');
+                        for (var i = 0; i < lines.length; i++) {
+                            if (!lines[i].startsWith('#') && lines[i].includes('.m3u8')) {
+                                streamInfo.Urls[lines[i]] = -1;
+                                if (i > 0 && lines[i - 1].startsWith('#EXT-X-STREAM-INF')) {
+                                    var res = parseAttributes(lines[i - 1])['RESOLUTION'];
+                                    if (res) {
+                                        streamInfo.Urls[lines[i]] = res;
+                                    }
+                                }
+                                StreamInfosByUrl[lines[i]] = streamInfo;
+                                MainUrlByUrl[lines[i]] = url;
                             }
-                        };
-                        var send = function() {
-                            return realFetch(url, options).then(function(response) {
-                                processAfter(response);
-                            })['catch'](function(err) {
-                                reject(err);
-                            });
-                        };
-                        send();
-                    });
-                }
+                        }
+                        resolve(new Response(encodingsM3u8));
+                    };
+                    var send = function() {
+                        return realFetch(url, options).then(function(response) {
+                            processAfter(response);
+                        })['catch'](function(err) {
+                            reject(err);
+                        });
+                    };
+                    send();
+                });
             }
         }
         return realFetch.apply(this, arguments);
     };
 }
 
-//Added as fallback for when UBlock method fails.
-async function getNewUsher(realFetch, originalResponse, channelName) {
-    var accessTokenResponse = await getAccessToken(channelName, PlayerType1);
-    var encodingsM3u8 = '';
+function shouldForceChangeQuality() {
+    return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+}
 
-    if (accessTokenResponse.status === 200) {
-
-        var accessToken = await accessTokenResponse.json();
-
-        try {
-            var urlInfo = new URL('https://usher.ttvnw.net/api/channel/hls/' + channelName + '.m3u8' + UsherParams);
-            urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
-            urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
-            var encodingsM3u8Response = await realFetch(urlInfo.href);
-            if (encodingsM3u8Response.status === 200) {
-                encodingsM3u8 = await encodingsM3u8Response.text();
-                return encodingsM3u8;
-            } else {
-                return originalResponse;
+function getStreamUrlForResolution(targetResolution, encodingsM3u8) {
+    var encodingsLines = encodingsM3u8.replace('\r', '').split('\n');
+    var firstUrl = null;
+    for (var i = 0; i < encodingsLines.length; i++) {
+        if (!encodingsLines[i].startsWith('#') && encodingsLines[i].includes('.m3u8')) {
+            if (i > 0 && encodingsLines[i - 1].startsWith('#EXT-X-STREAM-INF')) {
+                var res = parseAttributes(encodingsLines[i - 1])['RESOLUTION'];
+                if (res && (!targetResolution || res == targetResolution)) {
+                    return encodingsLines[i];
+                }
+                if (firstUrl == null) {
+                    firstUrl = encodingsLines[i];
+                }
             }
-        } catch (err) {}
-        return originalResponse;
-    } else {
-        return originalResponse;
+        }
     }
+    return firstUrl;
+}
+
+async function getStreamForResolution(streamInfo, targetResolution, encodingsM3u8, fallbackStreamStr, playerType, realFetch) {
+    if (streamInfo.EncodingsM3U8Cache[playerType].Value == null || streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution) {
+        console.log(`Blocking ads (type:${playerType}, resolution:${targetResolution})`);
+    }
+    streamInfo.EncodingsM3U8Cache[playerType].Value = encodingsM3u8;
+    streamInfo.EncodingsM3U8Cache[playerType].Resolution = targetResolution;
+    var streamM3u8Url = getStreamUrlForResolution(targetResolution, encodingsM3u8);
+    var streamM3u8Response = await realFetch(streamM3u8Url);
+    if (streamM3u8Response.status == 200) {
+        var m3u8Text = await streamM3u8Response.text();
+        WasShowingAd = true;
+        if (HideBlockingMessage == false) {
+            postMessage({
+                key: 'ShowAdBlockBanner'
+            });
+        } else if (HideBlockingMessage == true) {
+            postMessage({
+                key: 'HideAdBlockBanner'
+            });
+        }
+
+        if (shouldForceChangeQuality) {
+            postMessage({
+                key: 'ForceChangeQuality'
+            });
+        }
+
+        return m3u8Text;
+    } else {
+        return fallbackStreamStr;
+    }
+}
+
+function stripUnusedParams(str, params) {
+    if (!params) {
+        params = [ 'token', 'sig' ];
+    }
+    var tempUrl = new URL('https://localhost/' + str);
+    for (var i = 0; i < params.length; i++) {
+        tempUrl.searchParams.delete(params[i]);
+    }
+    return tempUrl.pathname.substring(1) + tempUrl.search;
 }
 
 async function processM3U8(url, textStr, realFetch, playerType) {
     //Checks the m3u8 for ads and if it finds one, instead returns an ad-free stream.
 
+    var streamInfo = StreamInfosByUrl[url];
+    
     //Ad blocking for squad streams is disabled due to the way multiple weaver urls are used. No workaround so far.
     if (IsSquadStream == true) {
         return textStr;
@@ -389,51 +442,63 @@ async function processM3U8(url, textStr, realFetch, playerType) {
 
     if (haveAdTags) {
 
-        //Reduces ad frequency.
+        //Reduces ad frequency. TODO: Reduce the number of requests. This is really spamming Twitch with requests.
         try {
             tryNotifyTwitch(textStr);
         } catch (err) {}
 
+        var currentResolution = null;
+        if (streamInfo && streamInfo.Urls) {
+            for (const [resUrl, resName] of Object.entries(streamInfo.Urls)) {
+                if (resUrl == url) {
+                    currentResolution = resName;
+                    //console.log(resName);
+                    break;
+                }
+            }
+        }
+        
+        // Keep the m3u8 around for 60 seconds before requesting a new one
+        // TODO: Maybe only do this for the proxy method?
+        var encodingsM3U8Cache = streamInfo.EncodingsM3U8Cache[playerType];
+        if (encodingsM3U8Cache) {
+            if (encodingsM3U8Cache.Value && encodingsM3U8Cache.RequestTime >= Date.now() - 60000) {
+                try {
+                    var result = getStreamForResolution(streamInfo, currentResolution, encodingsM3U8Cache.Value, null, playerType, realFetch);
+                    if (result) {
+                        return result;
+                    }
+                } catch (err) {}
+            }
+        }
+        streamInfo.EncodingsM3U8Cache[playerType] = {
+            RequestTime: Date.now(),
+            Value: null,
+            Resolution: null
+        };
+        
+        if (playerType === 'proxy') {
+            try {
+                /*var tempUrl = stripUnusedParams(MainUrlByUrl[url]);
+                const match = /(hls|vod)\/(.+?)$/gim.exec(tempUrl);*/
+                var encodingsM3u8Response = await realFetch('https://api.ttv.lol/playlist/' + CurrentChannelName + '.m3u8%3Fallow_source%3Dtrue'/* + encodeURIComponent(match[2])*/, {headers: {'X-Donate-To': 'https://ttv.lol/donate'}});
+                if (encodingsM3u8Response.status === 200) {
+                    return getStreamForResolution(streamInfo, currentResolution, await encodingsM3u8Response.text(), textStr, playerType, realFetch);
+                }
+            } catch (err) {}
+            return textStr;
+        }
+        
         var accessTokenResponse = await getAccessToken(CurrentChannelName, playerType);
-
         if (accessTokenResponse.status === 200) {
-
             var accessToken = await accessTokenResponse.json();
-
             try {
                 var urlInfo = new URL('https://usher.ttvnw.net/api/channel/hls/' + CurrentChannelName + '.m3u8' + UsherParams);
                 urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
                 urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
                 var encodingsM3u8Response = await realFetch(urlInfo.href);
                 if (encodingsM3u8Response.status === 200) {
-
-                    var encodingsM3u8 = await encodingsM3u8Response.text();
-
-                    streamM3u8Url = encodingsM3u8.match(/^https:.*\.m3u8$/mg)[0];
-
-                    var streamM3u8Response = await realFetch(streamM3u8Url);
-                    if (streamM3u8Response.status == 200) {
-                        var m3u8Text = await streamM3u8Response.text();
-                        console.log("Blocking ads...");
-                        WasShowingAd = true;
-                        if (HideBlockingMessage == false) {
-                            postMessage({
-                                key: 'ShowAdBlockBanner'
-                            });
-                        } else if (HideBlockingMessage == true) {
-                            postMessage({
-                                key: 'HideAdBlockBanner'
-                            });
-                        }
-
-                        postMessage({
-                            key: 'ForceChangeQuality'
-                        });
-
-                        return m3u8Text;
-                    } else {
-                        return textStr;
-                    }
+                    return getStreamForResolution(streamInfo, currentResolution, await encodingsM3u8Response.text(), textStr, playerType, realFetch);
                 } else {
                     return textStr;
                 }
@@ -447,10 +512,12 @@ async function processM3U8(url, textStr, realFetch, playerType) {
             console.log("Done blocking ads, changing back to original quality");
             WasShowingAd = false;
             //Here we put player back to original quality and remove the blocking message.
-            postMessage({
-                key: 'ForceChangeQuality',
-                value: 'original'
-            });
+            if (shouldForceChangeQuality) {
+                postMessage({
+                    key: 'ForceChangeQuality',
+                    value: 'original'
+                });
+            }
             postMessage({
                 key: 'PauseResumePlayer'
             });

--- a/chrome/remove_video_ads.js
+++ b/chrome/remove_video_ads.js
@@ -73,6 +73,7 @@ function declareOptions(scope) {
     scope.StreamInfos = [];
     scope.StreamInfosByUrl = [];
     scope.MainUrlByUrl = [];
+    scope.EncodingCacheTimeout = 60000;
 }
 
 declareOptions(window);
@@ -376,7 +377,8 @@ function getStreamUrlForResolution(targetResolution, encodingsM3u8) {
 }
 
 async function getStreamForResolution(streamInfo, targetResolution, encodingsM3u8, fallbackStreamStr, playerType, realFetch) {
-    if (streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution) {
+    if (streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution ||
+        streamInfo.EncodingsM3U8Cache[playerType].RequestTime < Date.now() - EncodingCacheTimeout) {
         console.log(`Blocking ads (type:${playerType}, resolution:${targetResolution})`);
     }
     streamInfo.EncodingsM3U8Cache[playerType].RequestTime = Date.now();
@@ -468,10 +470,10 @@ async function processM3U8(url, textStr, realFetch, playerType) {
             }
         }
         
-        // Keep the m3u8 around for 60 seconds before requesting a new one
+        // Keep the m3u8 around for a little while (once per ad) before requesting a new one
         var encodingsM3U8Cache = streamInfo.EncodingsM3U8Cache[playerType];
         if (encodingsM3U8Cache) {
-            if (encodingsM3U8Cache.Value && encodingsM3U8Cache.RequestTime >= Date.now() - 60000) {
+            if (encodingsM3U8Cache.Value && encodingsM3U8Cache.RequestTime >= Date.now() - EncodingCacheTimeout) {
                 try {
                     var result = getStreamForResolution(streamInfo, currentResolution, encodingsM3U8Cache.Value, null, playerType, realFetch);
                     if (result) {

--- a/chrome/remove_video_ads.js
+++ b/chrome/remove_video_ads.js
@@ -100,7 +100,6 @@ window.Worker = class Worker extends oldWorker {
             return;
         }
         var newBlobStr = `
-            ${shouldForceChangeQuality.toString()}
             ${getStreamUrlForResolution.toString()}
             ${getStreamForResolution.toString()}
             ${stripUnusedParams.toString()}
@@ -154,6 +153,9 @@ window.Worker = class Worker extends oldWorker {
             } else if (e.data.key == 'ForceChangeQuality') {
                 //This is used to fix the bug where the video would freeze.
                 try {
+                    if (navigator.userAgent.toLowerCase().indexOf('firefox') == -1) {
+                        return;
+                    }
                     var autoQuality = doTwitchPlayerTask(false, false, false, true, false);
                     var currentQuality = doTwitchPlayerTask(false, true, false, false, false);
 
@@ -353,10 +355,6 @@ function hookWorkerFetch() {
     };
 }
 
-function shouldForceChangeQuality() {
-    return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-}
-
 function getStreamUrlForResolution(targetResolution, encodingsM3u8) {
     var encodingsLines = encodingsM3u8.replace('\r', '').split('\n');
     var firstUrl = null;
@@ -399,11 +397,9 @@ async function getStreamForResolution(streamInfo, targetResolution, encodingsM3u
             });
         }
 
-        if (shouldForceChangeQuality) {
-            postMessage({
-                key: 'ForceChangeQuality'
-            });
-        }
+        postMessage({
+            key: 'ForceChangeQuality'
+        });
 
         if (!m3u8Text || m3u8Text.includes(AdSignifier)) {
             streamInfo.EncodingsM3U8Cache[playerType].Value = null;
@@ -526,12 +522,10 @@ async function processM3U8(url, textStr, realFetch, playerType) {
             console.log("Done blocking ads, changing back to original quality");
             WasShowingAd = false;
             //Here we put player back to original quality and remove the blocking message.
-            if (shouldForceChangeQuality) {
-                postMessage({
-                    key: 'ForceChangeQuality',
-                    value: 'original'
-                });
-            }
+            postMessage({
+                key: 'ForceChangeQuality',
+                value: 'original'
+            });
             postMessage({
                 key: 'PauseResumePlayer'
             });

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -101,6 +101,7 @@ function removeVideoAds() {
         scope.StreamInfos = [];
         scope.StreamInfosByUrl = [];
         scope.MainUrlByUrl = [];
+        scope.EncodingCacheTimeout = 60000;
     }
 
     declareOptions(window);
@@ -404,7 +405,8 @@ function removeVideoAds() {
     }
 
     async function getStreamForResolution(streamInfo, targetResolution, encodingsM3u8, fallbackStreamStr, playerType, realFetch) {
-        if (streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution) {
+        if (streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution ||
+            streamInfo.EncodingsM3U8Cache[playerType].RequestTime < Date.now() - EncodingCacheTimeout) {
             console.log(`Blocking ads (type:${playerType}, resolution:${targetResolution})`);
         }
         streamInfo.EncodingsM3U8Cache[playerType].RequestTime = Date.now();
@@ -496,10 +498,10 @@ function removeVideoAds() {
                 }
             }
             
-            // Keep the m3u8 around for 60 seconds before requesting a new one
+            // Keep the m3u8 around for a little while (once per ad) before requesting a new one
             var encodingsM3U8Cache = streamInfo.EncodingsM3U8Cache[playerType];
             if (encodingsM3U8Cache) {
-                if (encodingsM3U8Cache.Value && encodingsM3U8Cache.RequestTime >= Date.now() - 60000) {
+                if (encodingsM3U8Cache.Value && encodingsM3U8Cache.RequestTime >= Date.now() - EncodingCacheTimeout) {
                     try {
                         var result = getStreamForResolution(streamInfo, currentResolution, encodingsM3U8Cache.Value, null, playerType, realFetch);
                         if (result) {

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -88,16 +88,19 @@ function removeVideoAds() {
         scope.ClientID = 'kimne78kx3ncx6brgo4mv6wki5h1ko';
         scope.ClientVersion = 'null';
         scope.ClientSession = 'null';
-        scope.PlayerType1 = 'site'; //Source
-        scope.PlayerType2 = 'thunderdome'; //480p
-        scope.PlayerType3 = 'pop_tart'; //480p
-        scope.PlayerType4 = 'picture-by-picture'; //360p
+        //scope.PlayerType1 = 'site'; //Source - NOTE: This is unused as it's implicitly used by the website iself
+        scope.PlayerType2 = 'embed'; //Source
+        scope.PlayerType3 = 'proxy'; //Source
+        scope.PlayerType4 = 'thunderdome'; //480p
         scope.CurrentChannelName = null;
         scope.UsherParams = null;
         scope.WasShowingAd = false;
         scope.GQLDeviceID = null;
         scope.HideBlockingMessage = false;
         scope.IsSquadStream = false;
+        scope.StreamInfos = [];
+        scope.StreamInfosByUrl = [];
+        scope.MainUrlByUrl = [];
     }
 
     declareOptions(window);
@@ -124,7 +127,10 @@ function removeVideoAds() {
                 return;
             }
             var newBlobStr = `
-                ${getNewUsher.toString()}
+                ${shouldForceChangeQuality.toString()}
+                ${getStreamUrlForResolution.toString()}
+                ${getStreamForResolution.toString()}
+                ${stripUnusedParams.toString()}
                 ${processM3U8.toString()}
                 ${hookWorkerFetch.toString()}
                 ${declareOptions.toString()}
@@ -293,6 +299,7 @@ function removeVideoAds() {
     }
 
     function hookWorkerFetch() {
+        console.log('Twitch adblocker is enabled');
         var realFetch = fetch;
         fetch = async function(url, options) {
             if (typeof url === 'string') {
@@ -332,73 +339,119 @@ function removeVideoAds() {
                     if (isPBYPRequest) {
                         url = '';
                     }
-                    //Make new Usher request if needed to create fallback if UBlock bypass method fails.
-                    var useNewUsher = false;
-                    if (url.includes('subscriber%22%3Afalse') && url.includes('hide_ads%22%3Afalse') && url.includes('show_ads%22%3Atrue')) {
-                        useNewUsher = true;
-                    }
-                    if (url.includes('subscriber%22%3Atrue') && url.includes('hide_ads%22%3Afalse') && url.includes('show_ads%22%3Atrue')) {
-                        useNewUsher = true;
-                    }
-                    if (useNewUsher == true) {
-                        return new Promise(function(resolve, reject) {
-                            var processAfter = async function(response) {
-                                encodingsM3u8 = await getNewUsher(realFetch, response, channelName);
-                                if (encodingsM3u8.length > 1) {
-                                    resolve(new Response(encodingsM3u8));
-                                } else {
-                                    postMessage({
-                                        key: 'HideAdBlockBanner'
-                                    });
-                                    resolve(encodingsM3u8);
+                    return new Promise(function(resolve, reject) {
+                        var processAfter = async function(response) {
+                            encodingsM3u8 = await response.text();
+                            var streamInfo = StreamInfos[channelName];
+                            if (streamInfo == null) {
+                                StreamInfos[channelName] = streamInfo = {};
+                            }
+                            streamInfo.ChannelName = channelName;
+                            streamInfo.Urls = [];// xxx.m3u8 -> "284x160" (resolution)
+                            streamInfo.EncodingsM3U8Cache = [];
+                            var lines = encodingsM3u8.replace('\r', '').split('\n');
+                            for (var i = 0; i < lines.length; i++) {
+                                if (!lines[i].startsWith('#') && lines[i].includes('.m3u8')) {
+                                    streamInfo.Urls[lines[i]] = -1;
+                                    if (i > 0 && lines[i - 1].startsWith('#EXT-X-STREAM-INF')) {
+                                        var res = parseAttributes(lines[i - 1])['RESOLUTION'];
+                                        if (res) {
+                                            streamInfo.Urls[lines[i]] = res;
+                                        }
+                                    }
+                                    StreamInfosByUrl[lines[i]] = streamInfo;
+                                    MainUrlByUrl[lines[i]] = url;
                                 }
-                            };
-                            var send = function() {
-                                return realFetch(url, options).then(function(response) {
-                                    processAfter(response);
-                                })['catch'](function(err) {
-                                    reject(err);
-                                });
-                            };
-                            send();
-                        });
-                    }
+                            }
+                            resolve(new Response(encodingsM3u8));
+                        };
+                        var send = function() {
+                            return realFetch(url, options).then(function(response) {
+                                processAfter(response);
+                            })['catch'](function(err) {
+                                reject(err);
+                            });
+                        };
+                        send();
+                    });
                 }
             }
             return realFetch.apply(this, arguments);
         };
     }
 
-    //Added as fallback for when UBlock method fails.
-    async function getNewUsher(realFetch, originalResponse, channelName) {
-        var accessTokenResponse = await getAccessToken(channelName, PlayerType1);
-        var encodingsM3u8 = '';
+    function shouldForceChangeQuality() {
+        return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+    }
 
-        if (accessTokenResponse.status === 200) {
-
-            var accessToken = await accessTokenResponse.json();
-
-            try {
-                var urlInfo = new URL('https://usher.ttvnw.net/api/channel/hls/' + channelName + '.m3u8' + UsherParams);
-                urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
-                urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
-                var encodingsM3u8Response = await realFetch(urlInfo.href);
-                if (encodingsM3u8Response.status === 200) {
-                    encodingsM3u8 = await encodingsM3u8Response.text();
-                    return encodingsM3u8;
-                } else {
-                    return originalResponse;
+    function getStreamUrlForResolution(targetResolution, encodingsM3u8) {
+        var encodingsLines = encodingsM3u8.replace('\r', '').split('\n');
+        var firstUrl = null;
+        for (var i = 0; i < encodingsLines.length; i++) {
+            if (!encodingsLines[i].startsWith('#') && encodingsLines[i].includes('.m3u8')) {
+                if (i > 0 && encodingsLines[i - 1].startsWith('#EXT-X-STREAM-INF')) {
+                    var res = parseAttributes(encodingsLines[i - 1])['RESOLUTION'];
+                    if (res && (!targetResolution || res == targetResolution)) {
+                        return encodingsLines[i];
+                    }
+                    if (firstUrl == null) {
+                        firstUrl = encodingsLines[i];
+                    }
                 }
-            } catch (err) {}
-            return originalResponse;
-        } else {
-            return originalResponse;
+            }
         }
+        return firstUrl;
+    }
+
+    async function getStreamForResolution(streamInfo, targetResolution, encodingsM3u8, fallbackStreamStr, playerType, realFetch) {
+        if (streamInfo.EncodingsM3U8Cache[playerType].Value == null || streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution) {
+            console.log(`Blocking ads (type:${playerType}, resolution:${targetResolution})`);
+        }
+        streamInfo.EncodingsM3U8Cache[playerType].Value = encodingsM3u8;
+        streamInfo.EncodingsM3U8Cache[playerType].Resolution = targetResolution;
+        var streamM3u8Url = getStreamUrlForResolution(targetResolution, encodingsM3u8);
+        var streamM3u8Response = await realFetch(streamM3u8Url);
+        if (streamM3u8Response.status == 200) {
+            var m3u8Text = await streamM3u8Response.text();
+            WasShowingAd = true;
+            if (HideBlockingMessage == false) {
+                postMessage({
+                    key: 'ShowAdBlockBanner'
+                });
+            } else if (HideBlockingMessage == true) {
+                postMessage({
+                    key: 'HideAdBlockBanner'
+                });
+            }
+
+            if (shouldForceChangeQuality) {
+                postMessage({
+                    key: 'ForceChangeQuality'
+                });
+            }
+
+            return m3u8Text;
+        } else {
+            return fallbackStreamStr;
+        }
+    }
+
+    function stripUnusedParams(str, params) {
+        if (!params) {
+            params = [ 'token', 'sig' ];
+        }
+        var tempUrl = new URL('https://localhost/' + str);
+        for (var i = 0; i < params.length; i++) {
+            tempUrl.searchParams.delete(params[i]);
+        }
+        return tempUrl.pathname.substring(1) + tempUrl.search;
     }
 
     async function processM3U8(url, textStr, realFetch, playerType) {
         //Checks the m3u8 for ads and if it finds one, instead returns an ad-free stream.
 
+        var streamInfo = StreamInfosByUrl[url];
+        
         //Ad blocking for squad streams is disabled due to the way multiple weaver urls are used. No workaround so far.
         if (IsSquadStream == true) {
             return textStr;
@@ -417,50 +470,63 @@ function removeVideoAds() {
 
         if (haveAdTags) {
 
-            //Reduces ad frequency.
+            //Reduces ad frequency. TODO: Reduce the number of requests. This is really spamming Twitch with requests.
             try {
                 tryNotifyTwitch(textStr);
             } catch (err) {}
 
+            var currentResolution = null;
+            if (streamInfo && streamInfo.Urls) {
+                for (const [resUrl, resName] of Object.entries(streamInfo.Urls)) {
+                    if (resUrl == url) {
+                        currentResolution = resName;
+                        //console.log(resName);
+                        break;
+                    }
+                }
+            }
+            
+            // Keep the m3u8 around for 60 seconds before requesting a new one
+            // TODO: Maybe only do this for the proxy method?
+            var encodingsM3U8Cache = streamInfo.EncodingsM3U8Cache[playerType];
+            if (encodingsM3U8Cache) {
+                if (encodingsM3U8Cache.Value && encodingsM3U8Cache.RequestTime >= Date.now() - 60000) {
+                    try {
+                        var result = getStreamForResolution(streamInfo, currentResolution, encodingsM3U8Cache.Value, null, playerType, realFetch);
+                        if (result) {
+                            return result;
+                        }
+                    } catch (err) {}
+                }
+            }
+            streamInfo.EncodingsM3U8Cache[playerType] = {
+                RequestTime: Date.now(),
+                Value: null,
+                Resolution: null
+            };
+            
+            if (playerType === 'proxy') {
+                try {
+                    /*var tempUrl = stripUnusedParams(MainUrlByUrl[url]);
+                    const match = /(hls|vod)\/(.+?)$/gim.exec(tempUrl);*/
+                    var encodingsM3u8Response = await realFetch('https://api.ttv.lol/playlist/' + CurrentChannelName + '.m3u8%3Fallow_source%3Dtrue'/* + encodeURIComponent(match[2])*/, {headers: {'X-Donate-To': 'https://ttv.lol/donate'}});
+                    if (encodingsM3u8Response.status === 200) {
+                        return getStreamForResolution(streamInfo, currentResolution, await encodingsM3u8Response.text(), textStr, playerType, realFetch);
+                    }
+                } catch (err) {}
+                return textStr;
+            }
+            
             var accessTokenResponse = await getAccessToken(CurrentChannelName, playerType);
-
             if (accessTokenResponse.status === 200) {
-
                 var accessToken = await accessTokenResponse.json();
-
                 try {
                     var urlInfo = new URL('https://usher.ttvnw.net/api/channel/hls/' + CurrentChannelName + '.m3u8' + UsherParams);
                     urlInfo.searchParams.set('sig', accessToken.data.streamPlaybackAccessToken.signature);
                     urlInfo.searchParams.set('token', accessToken.data.streamPlaybackAccessToken.value);
                     var encodingsM3u8Response = await realFetch(urlInfo.href);
                     if (encodingsM3u8Response.status === 200) {
-
-                        var encodingsM3u8 = await encodingsM3u8Response.text();
-
-                        streamM3u8Url = encodingsM3u8.match(/^https:.*\.m3u8$/mg)[0];
-
-                        var streamM3u8Response = await realFetch(streamM3u8Url);
-                        if (streamM3u8Response.status == 200) {
-                            var m3u8Text = await streamM3u8Response.text();
-                            WasShowingAd = true;
-                            if (HideBlockingMessage == false) {
-                                    postMessage({
-                                        key: 'ShowAdBlockBanner'
-                                    });
-                            } else if (HideBlockingMessage == true) {
-                                postMessage({
-                                    key: 'HideAdBlockBanner'
-                                });
-                            }
-
-                            postMessage({
-                                key: 'ForceChangeQuality'
-                            });
-
-                            return m3u8Text;
-                        } else {
-                            return textStr;
-                        }
+                        return getStreamForResolution(streamInfo, currentResolution, await encodingsM3u8Response.text(), textStr, playerType, realFetch);
                     } else {
                         return textStr;
                     }
@@ -471,12 +537,15 @@ function removeVideoAds() {
             }
         } else {
             if (WasShowingAd) {
+                console.log("Done blocking ads, changing back to original quality");
                 WasShowingAd = false;
                 //Here we put player back to original quality and remove the blocking message.
-                postMessage({
-                    key: 'ForceChangeQuality',
-                    value: 'original'
-                });
+                if (shouldForceChangeQuality) {
+                    postMessage({
+                        key: 'ForceChangeQuality',
+                        value: 'original'
+                    });
+                }
                 postMessage({
                     key: 'PauseResumePlayer'
                 });

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -404,9 +404,10 @@ function removeVideoAds() {
     }
 
     async function getStreamForResolution(streamInfo, targetResolution, encodingsM3u8, fallbackStreamStr, playerType, realFetch) {
-        if (streamInfo.EncodingsM3U8Cache[playerType].Value == null || streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution) {
+        if (streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution) {
             console.log(`Blocking ads (type:${playerType}, resolution:${targetResolution})`);
         }
+        streamInfo.EncodingsM3U8Cache[playerType].RequestTime = Date.now();
         streamInfo.EncodingsM3U8Cache[playerType].Value = encodingsM3u8;
         streamInfo.EncodingsM3U8Cache[playerType].Resolution = targetResolution;
         var streamM3u8Url = getStreamUrlForResolution(targetResolution, encodingsM3u8);
@@ -430,8 +431,13 @@ function removeVideoAds() {
                 });
             }
 
+            if (!m3u8Text || m3u8Text.includes(AdSignifier)) {
+                streamInfo.EncodingsM3U8Cache[playerType].Value = null;
+            }
+
             return m3u8Text;
         } else {
+            streamInfo.EncodingsM3U8Cache[playerType].Value = null;
             return fallbackStreamStr;
         }
     }
@@ -470,10 +476,14 @@ function removeVideoAds() {
 
         if (haveAdTags) {
 
+            var isMidroll = textStr.includes('"MIDROLL"') || textStr.includes('"midroll"');
+        
             //Reduces ad frequency. TODO: Reduce the number of requests. This is really spamming Twitch with requests.
-            try {
-                tryNotifyTwitch(textStr);
-            } catch (err) {}
+            if (!isMidroll) {
+                try {
+                    tryNotifyTwitch(textStr);
+                } catch (err) {}
+            }
 
             var currentResolution = null;
             if (streamInfo && streamInfo.Urls) {
@@ -487,7 +497,6 @@ function removeVideoAds() {
             }
             
             // Keep the m3u8 around for 60 seconds before requesting a new one
-            // TODO: Maybe only do this for the proxy method?
             var encodingsM3U8Cache = streamInfo.EncodingsM3U8Cache[playerType];
             if (encodingsM3U8Cache) {
                 if (encodingsM3U8Cache.Value && encodingsM3U8Cache.RequestTime >= Date.now() - 60000) {
@@ -496,14 +505,17 @@ function removeVideoAds() {
                         if (result) {
                             return result;
                         }
-                    } catch (err) {}
+                    } catch (err) {
+                        encodingsM3U8Cache.Value = null;
+                    }
                 }
+            } else {
+                streamInfo.EncodingsM3U8Cache[playerType] = {
+                    RequestTime: Date.now(),
+                    Value: null,
+                    Resolution: null
+                };
             }
-            streamInfo.EncodingsM3U8Cache[playerType] = {
-                RequestTime: Date.now(),
-                Value: null,
-                Resolution: null
-            };
             
             if (playerType === 'proxy') {
                 try {

--- a/firefox/content.js
+++ b/firefox/content.js
@@ -128,7 +128,6 @@ function removeVideoAds() {
                 return;
             }
             var newBlobStr = `
-                ${shouldForceChangeQuality.toString()}
                 ${getStreamUrlForResolution.toString()}
                 ${getStreamForResolution.toString()}
                 ${stripUnusedParams.toString()}
@@ -182,6 +181,9 @@ function removeVideoAds() {
                 } else if (e.data.key == 'ForceChangeQuality') {
                     //This is used to fix the bug where the video would freeze.
                     try {
+                        if (navigator.userAgent.toLowerCase().indexOf('firefox') == -1) {
+                            return;
+                        }
                         var autoQuality = doTwitchPlayerTask(false, false, false, true, false);
                         var currentQuality = doTwitchPlayerTask(false, true, false, false, false);
 
@@ -381,10 +383,6 @@ function removeVideoAds() {
         };
     }
 
-    function shouldForceChangeQuality() {
-        return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-    }
-
     function getStreamUrlForResolution(targetResolution, encodingsM3u8) {
         var encodingsLines = encodingsM3u8.replace('\r', '').split('\n');
         var firstUrl = null;
@@ -427,11 +425,9 @@ function removeVideoAds() {
                 });
             }
 
-            if (shouldForceChangeQuality) {
-                postMessage({
-                    key: 'ForceChangeQuality'
-                });
-            }
+            postMessage({
+                key: 'ForceChangeQuality'
+            });
 
             if (!m3u8Text || m3u8Text.includes(AdSignifier)) {
                 streamInfo.EncodingsM3U8Cache[playerType].Value = null;
@@ -554,12 +550,10 @@ function removeVideoAds() {
                 console.log("Done blocking ads, changing back to original quality");
                 WasShowingAd = false;
                 //Here we put player back to original quality and remove the blocking message.
-                if (shouldForceChangeQuality) {
-                    postMessage({
-                        key: 'ForceChangeQuality',
-                        value: 'original'
-                    });
-                }
+                postMessage({
+                    key: 'ForceChangeQuality',
+                    value: 'original'
+                });
                 postMessage({
                     key: 'PauseResumePlayer'
                 });


### PR DESCRIPTION
This is a rough implementation of using the embed player, followed by a proxy (ttv.lol), and falling back to the `Commercial Break in Progress` screen if both of these fail.

Some notes about the changes:

- If the embed player kicks in it wont contact the proxy server which should help reduce any additional traffic to their service.
- Both embed and proxy should run at the same resolution as the current player (no more 480p... except on Firefox for the time being)
- One request to the main m3u8 has been removed which never really did anything useful (as far as I can tell)
- I have removed the stream quality change code path from the chrome code as I don't think it helps and it's annoying. It's still enabled on Firefox as it does help with freezing issues there

I haven't really tested this. I've only tested prerolls. Please test thoroughly before merging.
