### PR TITLE
Improvements to the hybrid embed proxy code

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -1,16 +1,15 @@
 // Show options and install message on first install only.
 function handleInstalled(details) {
-  if (details.reason == "install") {
-    let createData = {
-      focused: true,
-      type: "popup",
-      url: "popup/install.html",
-      width: 365,
-      height: 750,
-    };
-
-    chrome.windows.create(createData);
-  }
+    if (details.reason == 'install') {
+        let createData = {
+            focused: true,
+            type: 'popup',
+            url: 'popup/install.html',
+            width: 365,
+            height: 750,
+        };
+        chrome.windows.create(createData);
+    }
 }
 
 chrome.runtime.onInstalled.addListener(handleInstalled);

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -1,71 +1,72 @@
 // Browser helpers
-const isChromium = typeof window.chrome !== "undefined";
-const isFirefox = typeof window.browser !== "undefined";
+const isChromium = typeof window.chrome !== 'undefined';
+const isFirefox = typeof window.browser !== 'undefined';
 const browser = isFirefox ? window.browser : window.chrome;
 
 // Get extension settings
 function updateSettings() {
-  const setHideBlockingMessage = ({ blockingMessageTTV }) => {
-    if (blockingMessageTTV === "true" || blockingMessageTTV === "false") {
-      postMessage(
-        {
-          type: "SetHideBlockingMessage",
-          value: blockingMessageTTV,
-        },
-        "*"
-      );
-    }
-  };
-
-  if (isFirefox) {
-    browser.storage.local
-      .get("blockingMessageTTV")
-      .then(setHideBlockingMessage);
-  } else {
-    browser.storage.local.get(["blockingMessageTTV"], (result) =>
-      setHideBlockingMessage(result)
-    );
-  }
+    browser.storage.local.get(['blockingMessageTTV','forcedQualityTTV','proxyTTV','proxyQualityTTV']).then(result => {
+        var settings = {
+            BannerVisible: true,
+            ForcedQuality: null,
+            ProxyType: null,
+            ProxyQuality: null,
+        };
+        if (result.blockingMessageTTV === 'true' || result.blockingMessageTTV === 'false') {
+            settings.BannerVisible = result.blockingMessageTTV === 'true';
+        }
+        if (result.forcedQualityTTV) {
+            settings.ForcedQuality = result.forcedQualityTTV;
+        }
+        if (result.proxyTTV) {
+            settings.ProxyType = result.proxyTTV;
+        }
+        if (result.proxyQualityTTV) {
+            settings.ProxyQuality = result.proxyQualityTTV;
+        }
+        postMessage({
+            type: 'SetTwitchAdblockSettings',
+            settings: settings,
+        }, '*');
+    });
 }
 
 function appendBlockingScript() {
-  const script = document.createElement("script");
-  script.src = browser.runtime.getURL("remove_video_ads.js");
-  script.onload = () => setTimeout(updateSettings, 4000);
-  (document.body || document.head || document.documentElement).appendChild(
-    script
-  );
+    const script = document.createElement('script');
+    script.src = browser.runtime.getURL('remove_video_ads.js');
+    script.onload = updateSettings;
+    (document.body || document.head || document.documentElement).appendChild(script);
 }
 
 if (isFirefox) {
-  browser.storage.local.get("onOffTTV").then(
-    (result) => {
-      if (result?.onOffTTV) {
-        if (result.onOffTTV === "true") {
-          appendBlockingScript();
+    browser.storage.local.get('onOffTTV').then(
+        (result) => {
+            if (result?.onOffTTV) {
+                if (result.onOffTTV === 'true') {
+                    appendBlockingScript();
+                }
+            } else {
+                appendBlockingScript();
+            }
+        },
+        (error) => {
+            console.error(error);
+            appendBlockingScript();
         }
-      } else {
-        appendBlockingScript();
-      }
-    },
-    (error) => {
-      console.error(error);
-      appendBlockingScript();
-    }
-  );
+    );
 } else {
-  browser.storage.local.get(["onOffTTV"], function (result) {
-    if (browser.runtime.lastError) {
-      console.error(browser.runtime.lastError);
-      appendBlockingScript();
-      return;
-    }
-    if (result?.onOffTTV) {
-      if (result.onOffTTV === "true") {
-        appendBlockingScript();
-      }
-    } else {
-      appendBlockingScript();
-    }
-  });
+    browser.storage.local.get(['onOffTTV'], function (result) {
+        if (browser.runtime.lastError) {
+            console.error(browser.runtime.lastError);
+            appendBlockingScript();
+            return;
+        }
+        if (result?.onOffTTV) {
+            if (result.onOffTTV === 'true') {
+                appendBlockingScript();
+            }
+        } else {
+            appendBlockingScript();
+        }
+    });
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
   "description": "Blocks Ads on Twitch.tv.",
   "manifest_version": 3,
   "name": "Twitch Adblock",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "icons": {
     "48": "icons/twitch-adblock-48x48.png",
     "96": "icons/twitch-adblock-96x96.png"

--- a/chrome/popup/index.html
+++ b/chrome/popup/index.html
@@ -83,6 +83,20 @@
             .slider.round:before {
                 border-radius: 50%;
             }
+            .dropdown {
+                float: right;
+                position: relative;
+                display: inline-block;
+                width: 130px;
+                height: 20px;
+                border-radius: 40px;
+                background-color: #805ac5;
+                font-family: Arial, sans-serif;
+                font-size: 14px;
+                /*font-weight: bold;*/
+                color: #fff;
+                border: 0px;
+            }
         </style>
     </head>
     <body>
@@ -91,16 +105,48 @@
             <p class="p2">
                 Twitch Adblocker Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox1" checked />
+                    <input type="checkbox" name="checkbox_ad" checked />
                     <span class="slider round"></span>
                 </label>
             </p>
             <p class="p2">
                 "Blocking Ads" message Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox2" checked />
+                    <input type="checkbox" name="checkbox_ad_msg" checked />
                     <span class="slider round"></span>
                 </label>
+            </p>
+            <!--<p class="p2">
+                Forced quality
+                <select class="dropdown" name="dropdown_forced_quality">
+                    <option>None</option>
+                    <option>Auto</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
+            </p>-->
+            <p class="p2">
+                Proxy
+                <select class="dropdown" name="dropdown_proxy">
+                    <option>None</option>
+                    <option>TTV LOL</option>
+                    <!--<option>Purple Adblock</option>-->
+                    <option>Falan</option>
+                </select>
+            </p>
+            <p class="p2">
+                Proxy quality
+                <select class="dropdown" name="dropdown_proxy_quality">
+                    <option>None</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
             </p>
             <p class="p2">Whenever you change a setting, you have to reload the Twitch tab(s).</p>
             <p class="p2" style="text-align: center;">

--- a/chrome/popup/install.html
+++ b/chrome/popup/install.html
@@ -79,9 +79,22 @@
             .slider.round {
                 border-radius: 40px;
             }
-
             .slider.round:before {
                 border-radius: 50%;
+            }
+            .dropdown {
+                float: right;
+                position: relative;
+                display: inline-block;
+                width: 130px;
+                height: 20px;
+                border-radius: 40px;
+                background-color: #805ac5;
+                font-family: Arial, sans-serif;
+                font-size: 14px;
+                /*font-weight: bold;*/
+                color: #fff;
+                border: 0px;
             }
         </style>
     </head>
@@ -93,16 +106,48 @@
             <p class="p2">
                 Twitch Adblocker Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox1" checked />
+                    <input type="checkbox" name="checkbox_ad" checked />
                     <span class="slider round"></span>
                 </label>
             </p>
             <p class="p2">
                 "Blocking Ads" message Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox2" checked />
+                    <input type="checkbox" name="checkbox_ad_msg" checked />
                     <span class="slider round"></span>
                 </label>
+            </p>
+            <!--<p class="p2">
+                Forced quality
+                <select class="dropdown" name="dropdown_forced_quality">
+                    <option>None</option>
+                    <option>Auto</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
+            </p>-->
+            <p class="p2">
+                Proxy
+                <select class="dropdown" name="dropdown_proxy">
+                    <option>None</option>
+                    <option>TTV LOL</option>
+                    <!--<option>Purple Adblock</option>-->
+                    <option>Falan</option>
+                </select>
+            </p>
+            <p class="p2">
+                Proxy quality
+                <select class="dropdown" name="dropdown_proxy_quality">
+                    <option>None</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
             </p>
             <p class="p1">You can access these settings at any time by clicking on the extension icon.</p>
             <p class="p2" style="text-align: center;">

--- a/chrome/popup/popupjs.js
+++ b/chrome/popup/popupjs.js
@@ -1,51 +1,56 @@
-"use strict";
+'use strict';
 
-var onOff = document.querySelector("input[name=checkbox1]");
-var blockingMessage = document.querySelector("input[name=checkbox2]");
+const isChromium = typeof window.chrome !== 'undefined';
+const isFirefox = typeof window.browser !== 'undefined';
+const browser = isFirefox ? window.browser : window.chrome;
 
-onOff.addEventListener('change', function() {
-    saveOptions();
-});
+var onOff = document.querySelector('input[name=checkbox_ad]');
+var blockingMessage = document.querySelector('input[name=checkbox_ad_msg]');
+var forcedQuality = document.querySelector('select[name=dropdown_forced_quality]');
+var proxy = document.querySelector('select[name=dropdown_proxy]');
+var proxyQuality = document.querySelector('select[name=dropdown_proxy_quality]');
 
-blockingMessage.addEventListener('change', function() {
-    saveOptions();
-});
+var allSettingsElements = [onOff,blockingMessage,forcedQuality,proxy,proxyQuality];
 
-function saveOptions() {
-    if (document.querySelector("input[name=checkbox1]").checked) {
-        chrome.storage.local.set({
-            onOffTTV: "true"
-        }, function() {});
-    } else {
-        chrome.storage.local.set({
-            onOffTTV: "false"
-        }, function() {});
-    }
-    if (document.querySelector("input[name=checkbox2]").checked) {
-        chrome.storage.local.set({
-            blockingMessageTTV: "true"
-        }, function() {});
-    } else {
-        chrome.storage.local.set({
-            blockingMessageTTV: "false"
-        }, function() {});
+for (var i = 0; i < allSettingsElements.length; i++) {
+    if (allSettingsElements[i]) {
+        allSettingsElements[i].addEventListener('change', function() {
+            saveOptions();
+        });
     }
 }
 
+function saveOptions() {
+    chrome.storage.local.set({onOffTTV: onOff.checked ? 'true' : 'false'});
+    chrome.storage.local.set({blockingMessageTTV: blockingMessage.checked ? 'true' : 'false'});
+    //chrome.storage.local.set({forcedQualityTTV: forcedQuality.options[forcedQuality.selectedIndex].text});
+    chrome.storage.local.set({proxyTTV: proxy.options[proxy.selectedIndex].text});
+    chrome.storage.local.set({proxyQualityTTV: proxyQuality.options[proxyQuality.selectedIndex].text});
+}
+
 function restoreOptions() {
-    chrome.storage.local.get(['onOffTTV'], function(result) {
-        if (result.onOffTTV == "true") {
-            document.querySelector("input[name=checkbox1]").checked = true;
-        } else if (result.onOffTTV == "false") {
-            document.querySelector("input[name=checkbox1]").checked = false;
+    restoreToggle('onOffTTV', onOff);
+    restoreToggle('blockingMessageTTV', blockingMessage);
+    //restoreDropdown('forcedQualityTTV', forcedQuality);
+    restoreDropdown('proxyTTV', proxy);
+    restoreDropdown('proxyQualityTTV', proxyQuality);
+}
+
+function restoreToggle(name, toggle) {
+    chrome.storage.local.get([name], function(result) {
+        if (result[name]) {
+            toggle.checked = result[name] == 'true';
         }
     });
+}
 
-    chrome.storage.local.get(['blockingMessageTTV'], function(result) {
-        if (result.blockingMessageTTV == "true") {
-            document.querySelector("input[name=checkbox2]").checked = true;
-        } else if (result.blockingMessageTTV == "false") {
-            document.querySelector("input[name=checkbox2]").checked = false;
+function restoreDropdown(name, dropdown) {
+    chrome.storage.local.get([name], function(result) {
+        if (result[name]) {
+            var items = Array.from(dropdown.options).filter(item => item.text == result[name]);
+            if (items.length == 1) {
+                dropdown.selectedIndex = items[0].index;
+            }
         }
     });
 }

--- a/chrome/remove_video_ads.js
+++ b/chrome/remove_video_ads.js
@@ -42,16 +42,12 @@ try {
 } catch (err) {}
 
 //Send settings updates to worker.
-window.addEventListener("message", (event) => {
-    if (event.source != window)
+window.addEventListener('message', (event) => {
+    if (event.source != window) {
         return;
-    if (event.data.type && (event.data.type == "SetHideBlockingMessage")) {
-        if (twitchMainWorker) {
-            twitchMainWorker.postMessage({
-                key: 'SetHideBlockingMessage',
-                value: event.data.value
-            });
-        }
+    }
+    if (event.data.type && event.data.type == 'SetTwitchAdblockSettings' && event.data.settings) {
+        TwitchAdblockSettings = event.data.settings;
     }
 }, false);
 
@@ -68,24 +64,29 @@ function declareOptions(scope) {
     scope.UsherParams = null;
     scope.WasShowingAd = false;
     scope.GQLDeviceID = null;
-    scope.HideBlockingMessage = false;
     scope.IsSquadStream = false;
     scope.StreamInfos = [];
     scope.StreamInfosByUrl = [];
     scope.MainUrlByUrl = [];
     scope.EncodingCacheTimeout = 60000;
+    scope.DefaultProxyType = null;
+    scope.DefaultForcedQuality = null;
+    scope.DefaultProxyQuality = null;
 }
 
 declareOptions(window);
 
+var TwitchAdblockSettings = {
+    BannerVisible: true,
+    ForcedQuality: null,
+    ProxyType: null,
+    ProxyQuality: null,
+};
+
 var twitchMainWorker = null;
-
 var adBlockDiv = null;
-
 var OriginalVideoPlayerQuality = null;
-
 var IsPlayerAutoQuality = null;
-
 const oldWorker = window.Worker;
 
 window.Worker = class Worker extends oldWorker {
@@ -112,6 +113,7 @@ window.Worker = class Worker extends oldWorker {
             ${tryNotifyTwitch.toString()}
             ${parseAttributes.toString()}
             declareOptions(self);
+            self.TwitchAdblockSettings = ${JSON.stringify(TwitchAdblockSettings)};
             self.addEventListener('message', function(e) {
                 if (e.data.key == 'UpdateIsSquadStream') {
                     IsSquadStream = e.data.value;
@@ -123,12 +125,6 @@ window.Worker = class Worker extends oldWorker {
                     ClientID = e.data.value;
                 } else if (e.data.key == 'UpdateDeviceId') {
                     GQLDeviceID = e.data.value;
-                } else if (e.data.key == 'SetHideBlockingMessage') {
-                    if (e.data.value == "true") {
-                    HideBlockingMessage = false;
-                    } else if (e.data.value == "false") {
-                    HideBlockingMessage = true;
-                    }
                 }
             });
             hookWorkerFetch();
@@ -138,6 +134,9 @@ window.Worker = class Worker extends oldWorker {
         twitchMainWorker = this;
         this.onmessage = function(e) {
             if (e.data.key == 'ShowAdBlockBanner') {
+                if (!TwitchAdblockSettings.BannerVisible) {
+                    return;
+                }
                 if (adBlockDiv == null) {
                     adBlockDiv = getAdBlockDiv();
                 }
@@ -316,29 +315,39 @@ function hookWorkerFetch() {
                 }
                 return new Promise(function(resolve, reject) {
                     var processAfter = async function(response) {
-                        encodingsM3u8 = await response.text();
-                        var streamInfo = StreamInfos[channelName];
-                        if (streamInfo == null) {
-                            StreamInfos[channelName] = streamInfo = {};
-                        }
-                        streamInfo.ChannelName = channelName;
-                        streamInfo.Urls = [];// xxx.m3u8 -> "284x160" (resolution)
-                        streamInfo.EncodingsM3U8Cache = [];
-                        var lines = encodingsM3u8.replace('\r', '').split('\n');
-                        for (var i = 0; i < lines.length; i++) {
-                            if (!lines[i].startsWith('#') && lines[i].includes('.m3u8')) {
-                                streamInfo.Urls[lines[i]] = -1;
-                                if (i > 0 && lines[i - 1].startsWith('#EXT-X-STREAM-INF')) {
-                                    var res = parseAttributes(lines[i - 1])['RESOLUTION'];
-                                    if (res) {
-                                        streamInfo.Urls[lines[i]] = res;
-                                    }
-                                }
-                                StreamInfosByUrl[lines[i]] = streamInfo;
-                                MainUrlByUrl[lines[i]] = url;
+                        if (response.status == 200) {
+                            encodingsM3u8 = await response.text();
+                            var streamInfo = StreamInfos[channelName];
+                            if (streamInfo == null) {
+                                StreamInfos[channelName] = streamInfo = {};
                             }
+                            streamInfo.ChannelName = channelName;
+                            streamInfo.Urls = [];// xxx.m3u8 -> { Resolution: "284x160", FrameRate: 30.0 }
+                            streamInfo.EncodingsM3U8Cache = [];
+                            streamInfo.EncodingsM3U8 = encodingsM3u8;
+                            var lines = encodingsM3u8.replace('\r', '').split('\n');
+                            for (var i = 0; i < lines.length; i++) {
+                                if (!lines[i].startsWith('#') && lines[i].includes('.m3u8')) {
+                                    streamInfo.Urls[lines[i]] = -1;
+                                    if (i > 0 && lines[i - 1].startsWith('#EXT-X-STREAM-INF')) {
+                                        var attributes = parseAttributes(lines[i - 1]);
+                                        var resolution = attributes['RESOLUTION'];
+                                        var frameRate = attributes['FRAME-RATE'];
+                                        if (resolution) {
+                                            streamInfo.Urls[lines[i]] = {
+                                                Resolution: resolution,
+                                                FrameRate: frameRate
+                                            };
+                                        }
+                                    }
+                                    StreamInfosByUrl[lines[i]] = streamInfo;
+                                    MainUrlByUrl[lines[i]] = url;
+                                }
+                            }
+                            resolve(new Response(encodingsM3u8));
+                        } else {
+                            resolve(response);
                         }
-                        resolve(new Response(encodingsM3u8));
                     };
                     var send = function() {
                         return realFetch(url, options).then(function(response) {
@@ -355,48 +364,85 @@ function hookWorkerFetch() {
     };
 }
 
-function getStreamUrlForResolution(targetResolution, encodingsM3u8) {
+function getStreamUrlForResolution(encodingsM3u8, resolutionInfo, qualityOverrideStr) {
+    var qualityOverride = 0;
+    if (qualityOverrideStr && qualityOverrideStr.endsWith('p')) {
+        qualityOverride = qualityOverrideStr.substr(0, qualityOverrideStr.length - 1) | 0;
+    }
+    var qualityOverrideFoundQuality = 0;
+    var qualityOverrideFoundFrameRate = 0;
     var encodingsLines = encodingsM3u8.replace('\r', '').split('\n');
     var firstUrl = null;
+    var lastUrl = null;
+    var matchedResolutionUrl = null;
+    var matchedFrameRate = false;
     for (var i = 0; i < encodingsLines.length; i++) {
         if (!encodingsLines[i].startsWith('#') && encodingsLines[i].includes('.m3u8')) {
             if (i > 0 && encodingsLines[i - 1].startsWith('#EXT-X-STREAM-INF')) {
-                var res = parseAttributes(encodingsLines[i - 1])['RESOLUTION'];
-                if (res && (!targetResolution || res == targetResolution)) {
-                    return encodingsLines[i];
+                var attributes = parseAttributes(encodingsLines[i - 1]);
+                var resolution = attributes['RESOLUTION'];
+                var frameRate = attributes['FRAME-RATE'];
+                if (resolution) {
+                    if (qualityOverride) {
+                        var quality = resolution.toLowerCase().split('x')[1];
+                        if (quality == qualityOverride) {
+                            qualityOverrideFoundQuality = quality;
+                            qualityOverrideFoundFrameRate = frameRate;
+                            matchedResolutionUrl = encodingsLines[i];
+                            if (frameRate < 40) {
+                                //console.log(`qualityOverride(A) quality:${quality} frameRate:${frameRate}`);
+                                return matchedResolutionUrl;
+                            }
+                        } else if (quality < qualityOverride) {
+                            //if (matchedResolutionUrl) {
+                            //    console.log(`qualityOverride(B) quality:${qualityOverrideFoundQuality} frameRate:${qualityOverrideFoundFrameRate}`);
+                            //} else {
+                            //    console.log(`qualityOverride(C) quality:${quality} frameRate:${frameRate}`);
+                            //}
+                            return matchedResolutionUrl ? matchedResolutionUrl : encodingsLines[i];
+                        }
+                    } else if ((!resolutionInfo || resolution == resolutionInfo.Resolution) &&
+                               (!matchedResolutionUrl || (!matchedFrameRate && frameRate == resolutionInfo.FrameRate))) {
+                        matchedResolutionUrl = encodingsLines[i];
+                        matchedFrameRate = frameRate == resolutionInfo.FrameRate;
+                        if (matchedFrameRate) {
+                            return matchedResolutionUrl;
+                        }
+                    }
                 }
                 if (firstUrl == null) {
                     firstUrl = encodingsLines[i];
                 }
+                lastUrl = encodingsLines[i];
             }
         }
     }
-    return firstUrl;
+    if (qualityOverride) {
+        return lastUrl;
+    }
+    return matchedResolutionUrl ? matchedResolutionUrl : firstUrl;
 }
 
-async function getStreamForResolution(streamInfo, targetResolution, encodingsM3u8, fallbackStreamStr, playerType, realFetch) {
-    if (streamInfo.EncodingsM3U8Cache[playerType].Resolution != targetResolution ||
+async function getStreamForResolution(streamInfo, resolutionInfo, encodingsM3u8, fallbackStreamStr, playerType, realFetch) {
+    var qualityOverride = null;
+    if (playerType === 'proxy') {
+        qualityOverride = TwitchAdblockSettings.ProxyQuality ? TwitchAdblockSettings.ProxyQuality : DefaultProxyQuality;
+    }
+    if (streamInfo.EncodingsM3U8Cache[playerType].Resolution != resolutionInfo.Resolution ||
         streamInfo.EncodingsM3U8Cache[playerType].RequestTime < Date.now() - EncodingCacheTimeout) {
-        console.log(`Blocking ads (type:${playerType}, resolution:${targetResolution})`);
+        console.log(`Blocking ads (type:${playerType}, resolution:${resolutionInfo.Resolution}, frameRate:${resolutionInfo.FrameRate}, qualityOverride:${qualityOverride})`);
     }
     streamInfo.EncodingsM3U8Cache[playerType].RequestTime = Date.now();
     streamInfo.EncodingsM3U8Cache[playerType].Value = encodingsM3u8;
-    streamInfo.EncodingsM3U8Cache[playerType].Resolution = targetResolution;
-    var streamM3u8Url = getStreamUrlForResolution(targetResolution, encodingsM3u8);
+    streamInfo.EncodingsM3U8Cache[playerType].Resolution = resolutionInfo.Resolution;
+    var streamM3u8Url = getStreamUrlForResolution(encodingsM3u8, resolutionInfo, qualityOverride);
     var streamM3u8Response = await realFetch(streamM3u8Url);
     if (streamM3u8Response.status == 200) {
         var m3u8Text = await streamM3u8Response.text();
         WasShowingAd = true;
-        if (HideBlockingMessage == false) {
-            postMessage({
-                key: 'ShowAdBlockBanner'
-            });
-        } else if (HideBlockingMessage == true) {
-            postMessage({
-                key: 'HideAdBlockBanner'
-            });
-        }
-
+        postMessage({
+            key: 'ShowAdBlockBanner'
+        });
         postMessage({
             key: 'ForceChangeQuality'
         });
@@ -438,7 +484,7 @@ async function processM3U8(url, textStr, realFetch, playerType) {
     }
 
     //Some live streams use mp4.
-    if (!textStr.includes(".ts") && !textStr.includes(".mp4")) {
+    if (!textStr.includes('.ts') && !textStr.includes('.mp4')) {
         return textStr;
     }
 
@@ -451,16 +497,16 @@ async function processM3U8(url, textStr, realFetch, playerType) {
         //Reduces ad frequency. TODO: Reduce the number of requests. This is really spamming Twitch with requests.
         if (!isMidroll) {
             try {
-                tryNotifyTwitch(textStr);
+                //tryNotifyTwitch(textStr);
             } catch (err) {}
         }
 
         var currentResolution = null;
         if (streamInfo && streamInfo.Urls) {
-            for (const [resUrl, resName] of Object.entries(streamInfo.Urls)) {
+            for (const [resUrl, resInfo] of Object.entries(streamInfo.Urls)) {
                 if (resUrl == url) {
-                    currentResolution = resName;
-                    //console.log(resName);
+                    currentResolution = resInfo;
+                    //console.log(resInfo.Resolution);
                     break;
                 }
             }
@@ -489,10 +535,21 @@ async function processM3U8(url, textStr, realFetch, playerType) {
         
         if (playerType === 'proxy') {
             try {
+                var proxyType = TwitchAdblockSettings.ProxyType ? TwitchAdblockSettings.ProxyType : DefaultProxyType;
+                var encodingsM3u8Response = null;
                 /*var tempUrl = stripUnusedParams(MainUrlByUrl[url]);
                 const match = /(hls|vod)\/(.+?)$/gim.exec(tempUrl);*/
-                var encodingsM3u8Response = await realFetch('https://api.ttv.lol/playlist/' + CurrentChannelName + '.m3u8%3Fallow_source%3Dtrue'/* + encodeURIComponent(match[2])*/, {headers: {'X-Donate-To': 'https://ttv.lol/donate'}});
-                if (encodingsM3u8Response.status === 200) {
+                switch (proxyType) {
+                    case 'TTV LOL':
+                        encodingsM3u8Response = await realFetch('https://api.ttv.lol/playlist/' + CurrentChannelName + '.m3u8%3Fallow_source%3Dtrue'/* + encodeURIComponent(match[2])*/, {headers: {'X-Donate-To': 'https://ttv.lol/donate'}});
+                        break;
+                    /*case 'Purple Adblock':// Broken...
+                        encodingsM3u8Response = await realFetch('https://eu1.jupter.ga/channel/' + CurrentChannelName);*/
+                    case 'Falan':// https://greasyfork.org/en/scripts/425139-twitch-ad-fix/code
+                        encodingsM3u8Response = await realFetch(atob('aHR0cHM6Ly9qaWdnbGUuYmV5cGF6YXJpZ3VydXN1LndvcmtlcnMuZGV2') + '/hls/' + CurrentChannelName + '.m3u8%3Fallow_source%3Dtrue'/* + encodeURIComponent(match[2])*/);
+                        break;
+                }
+                if (encodingsM3u8Response && encodingsM3u8Response.status === 200) {
                     return getStreamForResolution(streamInfo, currentResolution, await encodingsM3u8Response.text(), textStr, playerType, realFetch);
                 }
             } catch (err) {}
@@ -519,7 +576,7 @@ async function processM3U8(url, textStr, realFetch, playerType) {
         }
     } else {
         if (WasShowingAd) {
-            console.log("Done blocking ads, changing back to original quality");
+            console.log('Finished blocking ads');
             WasShowingAd = false;
             //Here we put player back to original quality and remove the blocking message.
             postMessage({

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -2,7 +2,7 @@
   "description": "Blocks Ads on Twitch.tv.",
   "manifest_version": 2,
   "name": "Twitch Adblock",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "icons": {
     "48": "icons/twitch-adblock-48x48.png",
     "96": "icons/twitch-adblock-96x96.png"

--- a/firefox/popup/index.html
+++ b/firefox/popup/index.html
@@ -1,4 +1,3 @@
-<!-- This HTML will be shown when clicked on Extension Icon-->
 <!DOCTYPE html>
 <html>
     <head>
@@ -84,6 +83,20 @@
             .slider.round:before {
                 border-radius: 50%;
             }
+            .dropdown {
+                float: right;
+                position: relative;
+                display: inline-block;
+                width: 130px;
+                height: 20px;
+                border-radius: 40px;
+                background-color: #805ac5;
+                font-family: Arial, sans-serif;
+                font-size: 14px;
+                /*font-weight: bold;*/
+                color: #fff;
+                border: 0px;
+            }
         </style>
     </head>
     <body>
@@ -92,16 +105,48 @@
             <p class="p2">
                 Twitch Adblocker Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox1" checked />
+                    <input type="checkbox" name="checkbox_ad" checked />
                     <span class="slider round"></span>
                 </label>
             </p>
             <p class="p2">
                 "Blocking Ads" message Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox2" checked />
+                    <input type="checkbox" name="checkbox_ad_msg" checked />
                     <span class="slider round"></span>
                 </label>
+            </p>
+            <!--<p class="p2">
+                Forced quality
+                <select class="dropdown" name="dropdown_forced_quality">
+                    <option>None</option>
+                    <option>Auto</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
+            </p>-->
+            <p class="p2">
+                Proxy
+                <select class="dropdown" name="dropdown_proxy">
+                    <option>None</option>
+                    <option>TTV LOL</option>
+                    <!--<option>Purple Adblock</option>-->
+                    <option>Falan</option>
+                </select>
+            </p>
+            <p class="p2">
+                Proxy quality
+                <select class="dropdown" name="dropdown_proxy_quality">
+                    <option>None</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
             </p>
             <p class="p2">Whenever you change a setting, you have to reload the Twitch tab(s).</p>
             <p class="p2" style="text-align: center;">

--- a/firefox/popup/install.html
+++ b/firefox/popup/install.html
@@ -1,4 +1,3 @@
-<!-- This HTML will be shown on first installation -->
 <!DOCTYPE html>
 <html>
     <head>
@@ -80,9 +79,22 @@
             .slider.round {
                 border-radius: 40px;
             }
-
             .slider.round:before {
                 border-radius: 50%;
+            }
+            .dropdown {
+                float: right;
+                position: relative;
+                display: inline-block;
+                width: 130px;
+                height: 20px;
+                border-radius: 40px;
+                background-color: #805ac5;
+                font-family: Arial, sans-serif;
+                font-size: 14px;
+                /*font-weight: bold;*/
+                color: #fff;
+                border: 0px;
             }
         </style>
     </head>
@@ -94,16 +106,48 @@
             <p class="p2">
                 Twitch Adblocker Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox1" checked />
+                    <input type="checkbox" name="checkbox_ad" checked />
                     <span class="slider round"></span>
                 </label>
             </p>
             <p class="p2">
                 "Blocking Ads" message Off / On
                 <label class="switch">
-                    <input type="checkbox" name="checkbox2" checked />
+                    <input type="checkbox" name="checkbox_ad_msg" checked />
                     <span class="slider round"></span>
                 </label>
+            </p>
+            <!--<p class="p2">
+                Forced quality
+                <select class="dropdown" name="dropdown_forced_quality">
+                    <option>None</option>
+                    <option>Auto</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
+            </p>-->
+            <p class="p2">
+                Proxy
+                <select class="dropdown" name="dropdown_proxy">
+                    <option>None</option>
+                    <option>TTV LOL</option>
+                    <!--<option>Purple Adblock</option>-->
+                    <option>Falan</option>
+                </select>
+            </p>
+            <p class="p2">
+                Proxy quality
+                <select class="dropdown" name="dropdown_proxy_quality">
+                    <option>None</option>
+                    <option>1080p</option>
+                    <option>720p</option>
+                    <option>480p</option>
+                    <option>360p</option>
+                    <option>160p</option>
+                </select>
             </p>
             <p class="p1">You can access these settings at any time by clicking on the extension icon.</p>
             <p class="p2" style="text-align: center;">

--- a/firefox/popup/popupjs.js
+++ b/firefox/popup/popupjs.js
@@ -1,52 +1,56 @@
-"use strict";
+'use strict';
 
-var onOff = document.querySelector("input[name=checkbox1]");
-var blockingMessage = document.querySelector("input[name=checkbox2]");
+const isChromium = typeof window.chrome !== 'undefined';
+const isFirefox = typeof window.browser !== 'undefined';
+const browser = isFirefox ? window.browser : window.chrome;
 
-onOff.addEventListener('change', function() {
-    saveOptions();
-});
+var onOff = document.querySelector('input[name=checkbox_ad]');
+var blockingMessage = document.querySelector('input[name=checkbox_ad_msg]');
+var forcedQuality = document.querySelector('select[name=dropdown_forced_quality]');
+var proxy = document.querySelector('select[name=dropdown_proxy]');
+var proxyQuality = document.querySelector('select[name=dropdown_proxy_quality]');
 
-blockingMessage.addEventListener('change', function() {
-    saveOptions();
-});
+var allSettingsElements = [onOff,blockingMessage,forcedQuality,proxy,proxyQuality];
 
-function saveOptions() {
-    if (document.querySelector("input[name=checkbox1]").checked) {
-        browser.storage.sync.set({
-            onOffTTV: "true"
-        });
-    } else {
-        browser.storage.sync.set({
-            onOffTTV: "false"
-        });
-    }
-    if (document.querySelector("input[name=checkbox2]").checked) {
-        browser.storage.sync.set({
-            blockingMessageTTV: "true"
-        });
-    } else {
-        browser.storage.sync.set({
-            blockingMessageTTV: "false"
+for (var i = 0; i < allSettingsElements.length; i++) {
+    if (allSettingsElements[i]) {
+        allSettingsElements[i].addEventListener('change', function() {
+            saveOptions();
         });
     }
 }
 
+function saveOptions() {
+    chrome.storage.local.set({onOffTTV: onOff.checked ? 'true' : 'false'});
+    chrome.storage.local.set({blockingMessageTTV: blockingMessage.checked ? 'true' : 'false'});
+    //chrome.storage.local.set({forcedQualityTTV: forcedQuality.options[forcedQuality.selectedIndex].text});
+    chrome.storage.local.set({proxyTTV: proxy.options[proxy.selectedIndex].text});
+    chrome.storage.local.set({proxyQualityTTV: proxyQuality.options[proxyQuality.selectedIndex].text});
+}
+
 function restoreOptions() {
-    var onOff = browser.storage.sync.get('onOffTTV');
-    onOff.then((res) => {
-        if (res.onOffTTV == "true") {
-            document.querySelector("input[name=checkbox1]").checked = true;
-        } else if (res.onOffTTV == "false") {
-            document.querySelector("input[name=checkbox1]").checked = false;
+    restoreToggle('onOffTTV', onOff);
+    restoreToggle('blockingMessageTTV', blockingMessage);
+    //restoreDropdown('forcedQualityTTV', forcedQuality);
+    restoreDropdown('proxyTTV', proxy);
+    restoreDropdown('proxyQualityTTV', proxyQuality);
+}
+
+function restoreToggle(name, toggle) {
+    chrome.storage.local.get([name], function(result) {
+        if (result[name]) {
+            toggle.checked = result[name] == 'true';
         }
     });
-    var blockingMessage = browser.storage.sync.get('blockingMessageTTV');
-    blockingMessage.then((res) => {
-        if (res.blockingMessageTTV == "true") {
-            document.querySelector("input[name=checkbox2]").checked = true;
-        } else if (res.blockingMessageTTV == "false") {
-            document.querySelector("input[name=checkbox2]").checked = false;
+}
+
+function restoreDropdown(name, dropdown) {
+    chrome.storage.local.get([name], function(result) {
+        if (result[name]) {
+            var items = Array.from(dropdown.options).filter(item => item.text == result[name]);
+            if (items.length == 1) {
+                dropdown.selectedIndex = items[0].index;
+            }
         }
     });
 }


### PR DESCRIPTION
Following on from #63 this adds proxy settings. There's TTV LOL and Falan. Purple Adblock wasn't included as it's broken but I wrote the code for it so you could just uncomment it if it gets fixed. The proxy defaults to being disabled and you can set a resolution to be used under the proxy.

I was going to add a quality setting to adjust the forced 480p that's used under Firefox but I honestly didn't want to break it as it's used to fix freezing / playback issues and it's fairly fragile.

I don't have any plans of adding anything more to this. I did a bit of testing on chrome / firefox but not a great deal. I could have broken something especially with firefox as I didn't spend much time on it there.