### PR TITLE
Feature: See the total time of ads blocked (Chrome)

### DIFF
--- a/chrome/content.js
+++ b/chrome/content.js
@@ -5,12 +5,13 @@ const browser = isFirefox ? window.browser : window.chrome;
 
 // Get extension settings
 function updateSettings() {
-    browser.storage.local.get(['blockingMessageTTV','forcedQualityTTV','proxyTTV','proxyQualityTTV']).then(result => {
+    browser.storage.local.get(['blockingMessageTTV','forcedQualityTTV','proxyTTV','proxyQualityTTV', 'adTimeTTV']).then(result => {
         var settings = {
             BannerVisible: true,
             ForcedQuality: null,
             ProxyType: null,
             ProxyQuality: null,
+            AdTime: 0
         };
         if (result.blockingMessageTTV === 'true' || result.blockingMessageTTV === 'false') {
             settings.BannerVisible = result.blockingMessageTTV === 'true';
@@ -24,12 +25,22 @@ function updateSettings() {
         if (result.proxyQualityTTV) {
             settings.ProxyQuality = result.proxyQualityTTV;
         }
+        if (result.adTimeTTV) {
+            settings.AdTime = result.adTimeTTV;
+        }
         postMessage({
             type: 'SetTwitchAdblockSettings',
             settings: settings,
         }, '*');
     });
 }
+
+window.addEventListener('message', (event) => {
+    if (event.data.type && event.data.type == 'SetTwitchAdTime') {
+        browser.storage.local.set({adTimeTTV: event.data.adtime});
+        console.log("Set ad time to " + event.data.adtime);
+    }
+});
 
 function appendBlockingScript() {
     const script = document.createElement('script');

--- a/chrome/popup/index.html
+++ b/chrome/popup/index.html
@@ -149,6 +149,7 @@
                 </select>
             </p>
             <p class="p2">Whenever you change a setting, you have to reload the Twitch tab(s).</p>
+            <p class="p2">Ads blocked for a total of <label id="ad_time">0h</label>.</p>
             <p class="p2" style="text-align: center;">
                 <a href="https://github.com/cleanlock/VideoAdBlockForTwitch" target="_blank"><img src="github.png" alt="Github" height="42px" width="42px"></a>
                 <a href="https://discord.gg/PSgWqf3v8V" target="_blank"><img src="discord.png" alt="Discord" height="42px" width="42px" style="margin-left: 10px;"></a>

--- a/chrome/popup/popupjs.js
+++ b/chrome/popup/popupjs.js
@@ -9,6 +9,7 @@ var blockingMessage = document.querySelector('input[name=checkbox_ad_msg]');
 var forcedQuality = document.querySelector('select[name=dropdown_forced_quality]');
 var proxy = document.querySelector('select[name=dropdown_proxy]');
 var proxyQuality = document.querySelector('select[name=dropdown_proxy_quality]');
+var adTime = document.querySelector('#ad_time');
 
 var allSettingsElements = [onOff,blockingMessage,forcedQuality,proxy,proxyQuality];
 
@@ -34,6 +35,7 @@ function restoreOptions() {
     //restoreDropdown('forcedQualityTTV', forcedQuality);
     restoreDropdown('proxyTTV', proxy);
     restoreDropdown('proxyQualityTTV', proxyQuality);
+    restoreAdtime('adTimeTTV', adTime);
 }
 
 function restoreToggle(name, toggle) {
@@ -51,6 +53,16 @@ function restoreDropdown(name, dropdown) {
             if (items.length == 1) {
                 dropdown.selectedIndex = items[0].index;
             }
+        }
+    });
+}
+
+function restoreAdtime(name, container) {
+    chrome.storage.local.get([name], function(result) {
+        if (result[name]) {
+            const hours = Math.trunc(result[name] / 3600);
+            const minutes = Math.trunc((result[name] - hours * 3600) / 60);
+            container.innerText = `${hours>0 ? hours+"h " : ""}${minutes>0 ? minutes+"min " : ""}${result[name] % 60}s`;
         }
     });
 }

--- a/chrome/popup/popupjs.js
+++ b/chrome/popup/popupjs.js
@@ -60,6 +60,7 @@ function restoreDropdown(name, dropdown) {
 function restoreAdtime(name, container) {
     chrome.storage.local.get([name], function(result) {
         if (result[name]) {
+            // only display hours / minutes if needed
             const hours = Math.trunc(result[name] / 3600);
             const minutes = Math.trunc((result[name] - hours * 3600) / 60);
             container.innerText = `${hours>0 ? hours+"h " : ""}${minutes>0 ? minutes+"min " : ""}${result[name] % 60}s`;

--- a/chrome/remove_video_ads.js
+++ b/chrome/remove_video_ads.js
@@ -284,7 +284,6 @@ window.Worker = class Worker extends oldWorker {
                     adBlockDiv.className = 'adblock-overlay';
                     adBlockDiv.innerHTML = '<div class="player-adblock-notice" style="color: white; background-color: rgba(0, 0, 0, 0.8); position: absolute; top: 0px; left: 0px; padding: 5px;"><p></p></div>';
                     adBlockDiv.style.display = 'none';
-                    //start time of the ad
                     adBlockDiv.P = adBlockDiv.querySelector('p');
                     playerRootDiv.appendChild(adBlockDiv);
                 }

--- a/chrome/remove_video_ads.js
+++ b/chrome/remove_video_ads.js
@@ -81,6 +81,7 @@ var TwitchAdblockSettings = {
     ForcedQuality: null,
     ProxyType: null,
     ProxyQuality: null,
+    AdTime: 0
 };
 
 var twitchMainWorker = null;
@@ -142,11 +143,38 @@ window.Worker = class Worker extends oldWorker {
                 }
                 adBlockDiv.P.textContent = 'Blocking ads...';
                 adBlockDiv.style.display = 'block';
+
+                //setting data-start-time as starting time of ad blocking
+                let startTime = adBlockDiv.getAttribute('data-start-time');
+                if (!startTime || startTime == 'null') {
+                    adBlockDiv.setAttribute('data-start-time', new Date().toISOString());
+                }
             } else if (e.data.key == 'HideAdBlockBanner') {
                 if (adBlockDiv == null) {
                     adBlockDiv = getAdBlockDiv();
                 }
                 adBlockDiv.style.display = 'none';
+
+                // calculate duration of last ads
+                let startTime = adBlockDiv.getAttribute('data-start-time');
+                if (startTime) {
+                    startTime = new Date(startTime);
+                    let duration = Math.round((new Date() - startTime) / 1000);
+                    
+                    if (isNaN(duration) || duration < 1) {
+                        console.log(`Duration (${duration}) is invalid, not saving time.`);
+                        return;
+                    }
+                    TwitchAdblockSettings.AdTime += duration;
+                    // post message to content.js to save adtime in local storage
+                    postMessage({
+                        type: 'SetTwitchAdTime',
+                        adtime: TwitchAdblockSettings.AdTime
+                    }, '*');
+
+                    adBlockDiv.setAttribute('data-start-time', null);
+                }
+                
             } else if (e.data.key == 'PauseResumePlayer') {
                 doTwitchPlayerTask(true, false, false, false, false);
             } else if (e.data.key == 'ForceChangeQuality') {
@@ -256,6 +284,7 @@ window.Worker = class Worker extends oldWorker {
                     adBlockDiv.className = 'adblock-overlay';
                     adBlockDiv.innerHTML = '<div class="player-adblock-notice" style="color: white; background-color: rgba(0, 0, 0, 0.8); position: absolute; top: 0px; left: 0px; padding: 5px;"><p></p></div>';
                     adBlockDiv.style.display = 'none';
+                    //start time of the ad
                     adBlockDiv.P = adBlockDiv.querySelector('p');
                     playerRootDiv.appendChild(adBlockDiv);
                 }


### PR DESCRIPTION
Hey,

this is my first contribution to this extension and I hope it can provide real value. 
With this change I propose a feature to display the total time of ads blocked by the extension. For now this is Chrome-only as I have not worked with Firefox yet, but it should be easy to transfer.

It adds a line to the popup stating the total time in 'hh mm ss' format,  as it can be seen in the following preview:
![Screenshot_276](https://user-images.githubusercontent.com/21990230/198912192-1e7c902a-ef88-48ba-97fd-140f4257f188.png)

The extension has been tested to work for longer periods of time in Chrome 106.0.5249.11. Of course feel free to change and use my additions as you like,

